### PR TITLE
Fix flaky test testSetValueField()

### DIFF
--- a/src/main/java/com/j256/ormlite/misc/VersionUtils.java
+++ b/src/main/java/com/j256/ormlite/misc/VersionUtils.java
@@ -10,7 +10,7 @@ import com.j256.ormlite.logger.LoggerFactory;
  */
 public class VersionUtils {
 
-	private static final String CORE_VERSION = "VERSION__5.6__";
+	private static final String CORE_VERSION = "VERSION__5.7-SNAPSHOT__";
 
 	private static Logger logger;
 	private static boolean thrownOnErrors = false;

--- a/src/main/java/com/j256/ormlite/misc/VersionUtils.java
+++ b/src/main/java/com/j256/ormlite/misc/VersionUtils.java
@@ -10,7 +10,7 @@ import com.j256.ormlite.logger.LoggerFactory;
  */
 public class VersionUtils {
 
-	private static final String CORE_VERSION = "VERSION__5.7-SNAPSHOT__";
+	private static final String CORE_VERSION = "VERSION__5.6__";
 
 	private static Logger logger;
 	private static boolean thrownOnErrors = false;

--- a/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
@@ -394,9 +394,9 @@ public class FieldTypeTest extends BaseCoreTest {
 		Field[] fields = LocalFoo.class.getDeclaredFields();
 		Arrays.sort(fields, new Comparator<Field>() {
 			public int compare(Field a, Field b) {
-			return a.getName().compareTo(b.getName());
+				return a.getName().compareTo(b.getName());
 			}
-			});
+		});
 		assertTrue(fields.length >= 4);
 		Field nameField = fields[1];
 		FieldType fieldType =

--- a/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
@@ -18,6 +18,8 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -390,8 +392,13 @@ public class FieldTypeTest extends BaseCoreTest {
 	@Test
 	public void testSetValueField() throws Exception {
 		Field[] fields = LocalFoo.class.getDeclaredFields();
+		Arrays.sort(fields, new Comparator<Field>() {
+			public int compare(Field a, Field b) {
+			return a.getName().compareTo(b.getName());
+			}
+			});
 		assertTrue(fields.length >= 4);
-		Field nameField = fields[0];
+		Field nameField = fields[1];
 		FieldType fieldType =
 				FieldType.createFieldType(databaseType, LocalFoo.class.getSimpleName(), nameField, LocalFoo.class);
 		LocalFoo foo = new LocalFoo();

--- a/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
+++ b/src/test/java/com/j256/ormlite/field/FieldTypeTest.java
@@ -394,11 +394,11 @@ public class FieldTypeTest extends BaseCoreTest {
 		Field[] fields = LocalFoo.class.getDeclaredFields();
 		Arrays.sort(fields, new Comparator<Field>() {
 			public int compare(Field a, Field b) {
-				return a.getName().compareTo(b.getName());
+				return b.getName().compareTo(a.getName());
 			}
 		});
 		assertTrue(fields.length >= 4);
-		Field nameField = fields[1];
+		Field nameField = fields[2];
 		FieldType fieldType =
 				FieldType.createFieldType(databaseType, LocalFoo.class.getSimpleName(), nameField, LocalFoo.class);
 		LocalFoo foo = new LocalFoo();


### PR DESCRIPTION
I fix the flakiness in test `com.j256.ormlite.field.FieldTypeTest.testSetValueField`. The test was flaky when running the `nondex` tool. It was flaky because `getDeclaredFields()` is nondeterministic. I sort the Fields[] after I get them, so the name field will always be the second one in the Field[], then I get the name field by using` Field nameField = fields[1];`.